### PR TITLE
Check for presence of `editRF` before waterref reorder

### DIFF
--- a/SiemensTwixRead.m
+++ b/SiemensTwixRead.m
@@ -88,7 +88,10 @@ if nargin == 3
     MRS_struct.p.seqtype_water           = WaterHeader.seqtype;
     if isfield(WaterHeader,'deltaFreq')
         MRS_struct.p.Siemens.deltaFreq.water(ii) = WaterHeader.deltaFreq;
-        MRS_struct.p.Siemens = reorderstructure(MRS_struct.p.Siemens, 'editRF', 'deltaFreq');
+        
+        if isfield(WaterHeader, 'editRF')
+            MRS_struct.p.Siemens = reorderstructure(MRS_struct.p.Siemens, 'editRF', 'deltaFreq');
+        end
     end
     
     % If additional data points have been acquired before the echo starts,


### PR DESCRIPTION
Attempt to reorder the waterref struct fails in SiemensTwixRead.m without an `editRF` field. This PR adds a check before reorder.